### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # luci-app-scutclient
+* 将https://github.com/scutclient/scutclient/blob/master/openwrt/Makefile 放到 package/scutclient
 * 解压放到feeds/luci/applications
 * 再执行./scripts/feeds install -a -p luci
 * 然后make menuconfig


### PR DESCRIPTION
luci-app-scutclient依赖scutclient，若源码中没有scutclient的包，luci-app-scutclient缺乏依赖，不会出现在编译菜单里